### PR TITLE
alive_bar takes no arguments for increment

### DIFF
--- a/beetsplug/autofix/command.py
+++ b/beetsplug/autofix/command.py
@@ -80,9 +80,9 @@ class AutofixCommand(Subcommand):
         done = 0
         self._say("Total number of items: {}".format(len(items)))
         with alive_bar(len(items)) as bar:
-            for i, item in enumerate(items):
+            for item in items:
                 try:
-                    bar(i)
+                    bar()
                     self._execute_tasks_for_item(item)
                     done += 1
                 except RuntimeError as err:

--- a/beetsplug/autofix/command.py
+++ b/beetsplug/autofix/command.py
@@ -80,9 +80,9 @@ class AutofixCommand(Subcommand):
         done = 0
         self._say("Total number of items: {}".format(len(items)))
         with alive_bar(len(items)) as bar:
-            for item in items:
+            for i, item in enumerate(items):
                 try:
-                    bar(str(item))
+                    bar(i)
                     self._execute_tasks_for_item(item)
                     done += 1
                 except RuntimeError as err:


### PR DESCRIPTION
This resolves #7. Once instantiated, `alive_bar` calls `bar_handle`, which (in non-manual mode) [takes a single argument `count` that defaults to 1](https://github.com/rsalmei/alive-progress/blob/cf97db5e5761ed315c717ae15684b7cdf20726c5/alive_progress/core/progress.py#L150). Since the progress is measuring items processed, incrementing by one should be the correct behavior here.